### PR TITLE
feat: スタイルを整える (#17)

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "eslint src"
   },
   "dependencies": {
     "@aws-sdk/client-sqs": "^3.1000.0",

--- a/src/app/components/ComicTable.tsx
+++ b/src/app/components/ComicTable.tsx
@@ -7,41 +7,66 @@ import TableContainer from "@mui/material/TableContainer";
 import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
 import Paper from "@mui/material/Paper";
+import { Box, Checkbox, CircularProgress, Link, Typography } from "@mui/material";
 import { Comic } from "../type";
-import { Checkbox } from "@mui/material";
 
 type Props = {
   comics: Comic[];
 };
 
 export default function ComicTable({ comics }: Props) {
-  if (!comics.length) return <div>Loading...</div>;
+  if (!comics.length)
+    return (
+      <Box display="flex" justifyContent="center" py={6}>
+        <CircularProgress />
+      </Box>
+    );
 
   return (
-    <TableContainer component={Paper} sx={{ maxWidth: "100vw" }}>
+    <TableContainer component={Paper} elevation={2}>
       <Table aria-label="simple table">
         <TableHead>
-          <TableRow>
-            <TableCell>タイトル</TableCell>
-            <TableCell>入力者</TableCell>
-            <TableCell>購入</TableCell>
+          <TableRow sx={{ bgcolor: "primary.main" }}>
+            <TableCell
+              sx={{ color: "#fff", fontWeight: "bold", width: "50%" }}
+            >
+              タイトル
+            </TableCell>
+            <TableCell sx={{ color: "#fff", fontWeight: "bold" }}>
+              入力者
+            </TableCell>
+            <TableCell sx={{ color: "#fff", fontWeight: "bold" }}>
+              購入
+            </TableCell>
           </TableRow>
         </TableHead>
         <TableBody>
-          {comics.map((comic) => (
+          {comics.map((comic, index) => (
             <TableRow
               key={comic.id}
-              sx={{ "&:last-child td, &:last-child th": { border: 0 } }}
+              hover
+              sx={{
+                bgcolor: index % 2 === 0 ? "background.paper" : "#F8FAFC",
+                "&:last-child td, &:last-child th": { border: 0 },
+              }}
             >
               <TableCell component="th" scope="row">
-                <a
+                <Link
                   href={`https://piccoma.com/web/search/result?word=${comic.title}`}
                   target="_blank"
+                  rel="noopener noreferrer"
+                  underline="hover"
+                  color="primary"
+                  fontWeight={500}
                 >
                   {comic.title}
-                </a>
+                </Link>
               </TableCell>
-              <TableCell>{comic.creator}</TableCell>
+              <TableCell>
+                <Typography variant="body2" color="text.secondary">
+                  {comic.creator || "—"}
+                </Typography>
+              </TableCell>
               <TableCell>
                 <Checkbox checked={comic.isPurchased} disabled />
               </TableCell>

--- a/src/app/components/RegisterModal.tsx
+++ b/src/app/components/RegisterModal.tsx
@@ -1,6 +1,16 @@
 "use client";
 
-import { Box, Button, Modal, TextField } from "@mui/material";
+import {
+  Box,
+  Button,
+  IconButton,
+  Modal,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import AddIcon from "@mui/icons-material/Add";
+import CloseIcon from "@mui/icons-material/Close";
 import { useState } from "react";
 import { FormValues } from "../type";
 import { useForm } from "react-hook-form";
@@ -43,17 +53,19 @@ export const RegisterModal = ({ onRegisterSuccess }: Props) => {
 
   return (
     <>
-      <Box textAlign="center" mb={2}>
-        <Button variant="contained" onClick={handleOpen}>
-          登録する
-        </Button>
-      </Box>
+      <Button
+        variant="contained"
+        startIcon={<AddIcon />}
+        onClick={handleOpen}
+        sx={{ boxShadow: 2 }}
+      >
+        登録する
+      </Button>
 
       <Modal
         open={open}
         onClose={handleClose}
         aria-labelledby="modal-title"
-        aria-describedby="modal-description"
       >
         <Box
           sx={{
@@ -61,35 +73,50 @@ export const RegisterModal = ({ onRegisterSuccess }: Props) => {
             top: "50%",
             left: "50%",
             transform: "translate(-50%, -50%)",
-            width: "70%",
+            width: { xs: "90%", sm: "480px" },
             bgcolor: "background.paper",
-            borderRadius: 2,
+            borderRadius: 3,
             boxShadow: 24,
             p: 4,
           }}
         >
           <Box
-            component="form"
-            onSubmit={handleSubmit(onSubmit)}
-            textAlign="center"
+            display="flex"
+            alignItems="center"
+            justifyContent="space-between"
+            mb={3}
           >
-            <TextField
-              label="タイトル"
-              {...register("title")}
-              fullWidth
-              margin="normal"
-            />
-            <TextField
-              label="入力者（任意）"
-              {...register("creator")}
-              fullWidth
-              margin="normal"
-            />
-            <Box mt={2}>
-              <Button type="submit" variant="contained" color="primary">
-                登録
-              </Button>
-            </Box>
+            <Typography id="modal-title" variant="h6" fontWeight="bold">
+              マンガを登録する
+            </Typography>
+            <IconButton size="small" onClick={handleClose}>
+              <CloseIcon fontSize="small" />
+            </IconButton>
+          </Box>
+
+          <Box component="form" onSubmit={handleSubmit(onSubmit)}>
+            <Stack spacing={2}>
+              <TextField
+                label="タイトル"
+                {...register("title")}
+                fullWidth
+                size="small"
+              />
+              <TextField
+                label="入力者（任意）"
+                {...register("creator")}
+                fullWidth
+                size="small"
+              />
+              <Box display="flex" justifyContent="flex-end" gap={1} pt={1}>
+                <Button variant="outlined" onClick={handleClose}>
+                  キャンセル
+                </Button>
+                <Button type="submit" variant="contained">
+                  登録
+                </Button>
+              </Box>
+            </Stack>
           </Box>
         </Box>
       </Modal>

--- a/src/app/components/ThemeRegistry.tsx
+++ b/src/app/components/ThemeRegistry.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { ThemeProvider, createTheme, CssBaseline } from "@mui/material";
+
+const theme = createTheme({
+  palette: {
+    primary: {
+      main: "#4F46E5",
+      light: "#818CF8",
+      dark: "#3730A3",
+    },
+    secondary: {
+      main: "#06B6D4",
+    },
+    background: {
+      default: "#F1F5F9",
+      paper: "#FFFFFF",
+    },
+  },
+  typography: {
+    fontFamily: [
+      "-apple-system",
+      "BlinkMacSystemFont",
+      '"Hiragino Sans"',
+      '"Noto Sans JP"',
+      "sans-serif",
+    ].join(","),
+  },
+  shape: {
+    borderRadius: 12,
+  },
+  components: {
+    MuiButton: {
+      styleOverrides: {
+        root: {
+          textTransform: "none",
+          fontWeight: 600,
+          borderRadius: 8,
+          paddingLeft: 24,
+          paddingRight: 24,
+        },
+      },
+    },
+    MuiPaper: {
+      styleOverrides: {
+        root: {
+          borderRadius: 12,
+        },
+      },
+    },
+    MuiTableCell: {
+      styleOverrides: {
+        root: {
+          paddingTop: 14,
+          paddingBottom: 14,
+        },
+      },
+    },
+  },
+});
+
+export function ThemeRegistry({ children }: { children: React.ReactNode }) {
+  return (
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      {children}
+    </ThemeProvider>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { AppRouterCacheProvider } from "@mui/material-nextjs/v15-appRouter";
+import { ThemeRegistry } from "./components/ThemeRegistry";
 
 export const metadata: Metadata = {
   title: "comics manager",
@@ -14,7 +15,9 @@ export default function RootLayout({
   return (
     <html lang="ja">
       <body>
-        <AppRouterCacheProvider>{children}</AppRouterCacheProvider>
+        <AppRouterCacheProvider>
+          <ThemeRegistry>{children}</ThemeRegistry>
+        </AppRouterCacheProvider>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { Box, Typography } from "@mui/material";
+import { Box, Container, Typography, AppBar, Toolbar } from "@mui/material";
+import MenuBookIcon from "@mui/icons-material/MenuBook";
 import ComicTable from "./components/ComicTable";
 import { RegisterModal } from "./components/RegisterModal";
 import { useState, useEffect } from "react";
@@ -20,18 +21,37 @@ export default function Home() {
   }, []);
 
   return (
-    <Box width="100%" py={4}>
-      <Typography
-        variant="h1"
-        gutterBottom
-        fontSize={24}
-        textAlign="center"
-        mb={4}
-      >
-        マンガ購入管理アプリ
-      </Typography>
-      <RegisterModal onRegisterSuccess={fetchComics} />
-      <ComicTable comics={comics} />
+    <Box
+      minHeight="100vh"
+      sx={{
+        background: "linear-gradient(135deg, #EEF2FF 0%, #E0F2FE 100%)",
+      }}
+    >
+      <AppBar position="static" elevation={0} sx={{ bgcolor: "primary.main" }}>
+        <Toolbar>
+          <MenuBookIcon sx={{ mr: 1.5 }} />
+          <Typography variant="h6" fontWeight="bold">
+            マンガ購入管理
+          </Typography>
+        </Toolbar>
+      </AppBar>
+
+      <Container maxWidth="md">
+        <Box py={5}>
+          <Box
+            display="flex"
+            alignItems="center"
+            justifyContent="space-between"
+            mb={3}
+          >
+            <Typography variant="h5" fontWeight="bold" color="text.primary">
+              リスト
+            </Typography>
+            <RegisterModal onRegisterSuccess={fetchComics} />
+          </Box>
+          <ComicTable comics={comics} />
+        </Box>
+      </Container>
     </Box>
   );
 }


### PR DESCRIPTION
- MUIカスタムテーマ (ThemeRegistry) を追加: インディゴ系カラー・角丸・フォント設定
- ThemeProviderをクライアントコンポーネントに分離
- AppBarとグラデーション背景をページに追加
- テーブルヘッダーをプライマリカラーに変更、ゼブラストライプ・hoverエフェクト追加
- リンクをMUI Linkコンポーネントに変更
- RegisterModalに閉じるボタン・キャンセルボタンを追加、レスポンシブ対応
- lintスクリプトをnext lint→eslint srcに修正 (Next.js 16でnext lintが廃止)

Closes #17 