### PR TITLE
feat: 購入状況タブでComicTableの表示を切り替える

### DIFF
--- a/src/app/components/ComicTable.tsx
+++ b/src/app/components/ComicTable.tsx
@@ -5,6 +5,8 @@ import {
   Checkbox,
   CircularProgress,
   Pagination,
+  Tab,
+  Tabs,
   Typography,
 } from "@mui/material";
 import Paper from "@mui/material/Paper";
@@ -24,10 +26,23 @@ type Props = {
 };
 
 export default function ComicTable({ comics }: Props) {
+  const [tab, setTab] = useState<0 | 1>(0);
   const [page, setPage] = useState(1);
   const ITEMS_PER_PAGE = 10;
+
+  const filteredComics = comics.filter((c) =>
+    tab === 0 ? !c.isPurchased : c.isPurchased
+  );
   const startIndex = (page - 1) * ITEMS_PER_PAGE;
-  const currentComics = comics.slice(startIndex, startIndex + ITEMS_PER_PAGE);
+  const currentComics = filteredComics.slice(
+    startIndex,
+    startIndex + ITEMS_PER_PAGE
+  );
+
+  const handleTabChange = (_: React.SyntheticEvent, newValue: 0 | 1) => {
+    setTab(newValue);
+    setPage(1);
+  };
 
   if (!comics.length)
     return (
@@ -38,6 +53,15 @@ export default function ComicTable({ comics }: Props) {
 
   return (
     <>
+      <Tabs
+        value={tab}
+        onChange={handleTabChange}
+        sx={{ mb: 1 }}
+        aria-label="購入状況タブ"
+      >
+        <Tab label="未購入" />
+        <Tab label="購入済" />
+      </Tabs>
       <TableContainer component={Paper} elevation={2}>
         <Table aria-label="simple table" size="small">
           <TableHead>
@@ -74,7 +98,7 @@ export default function ComicTable({ comics }: Props) {
       </TableContainer>
       <Box display="flex" justifyContent="center" mt={2}>
         <Pagination
-          count={Math.ceil(comics.length / ITEMS_PER_PAGE)}
+          count={Math.ceil(filteredComics.length / ITEMS_PER_PAGE)}
           page={page}
           onChange={(_, value) => setPage(value)}
         />

--- a/src/app/components/ComicTable.tsx
+++ b/src/app/components/ComicTable.tsx
@@ -18,7 +18,7 @@ import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
 import Image from "next/image";
 import Link from "next/link";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Comic } from "../type";
 
 type Props = {
@@ -28,9 +28,20 @@ type Props = {
 export default function ComicTable({ comics }: Props) {
   const [tab, setTab] = useState<0 | 1>(0);
   const [page, setPage] = useState(1);
+  const [localComics, setLocalComics] = useState<Comic[]>(comics);
   const ITEMS_PER_PAGE = 10;
 
-  const filteredComics = comics.filter((c) =>
+  useEffect(() => {
+    setLocalComics(comics);
+  }, [comics]);
+
+  const handleToggle = (id: string) => {
+    setLocalComics((prev) =>
+      prev.map((c) => (c.id === id ? { ...c, isPurchased: !c.isPurchased } : c))
+    );
+  };
+
+  const filteredComics = localComics.filter((c) =>
     tab === 0 ? !c.isPurchased : c.isPurchased
   );
   const startIndex = (page - 1) * ITEMS_PER_PAGE;
@@ -91,7 +102,7 @@ export default function ComicTable({ comics }: Props) {
           </TableHead>
           <TableBody>
             {currentComics.map((comic, index) => (
-              <ComicRow key={comic.id} comic={comic} index={index}></ComicRow>
+              <ComicRow key={comic.id} comic={comic} index={index} onToggle={handleToggle} />
             ))}
           </TableBody>
         </Table>
@@ -107,11 +118,17 @@ export default function ComicTable({ comics }: Props) {
   );
 }
 
-function ComicRow({ comic, index }: { comic: Comic; index: number }) {
-  const [isPurchased, setIsPurchased] = useState(comic.isPurchased);
+function ComicRow({
+  comic,
+  index,
+  onToggle,
+}: {
+  comic: Comic;
+  index: number;
+  onToggle: (id: string) => void;
+}) {
   const handleCheck = async () => {
-    const newValue = !isPurchased;
-    setIsPurchased(newValue);
+    onToggle(comic.id);
 
     await fetch("/api/notion", {
       method: "PATCH",
@@ -119,7 +136,7 @@ function ComicRow({ comic, index }: { comic: Comic; index: number }) {
       body: JSON.stringify({
         id: comic.id,
         title: comic.title,
-        isPurchased: newValue,
+        isPurchased: !comic.isPurchased,
       }),
     });
   };
@@ -160,7 +177,7 @@ function ComicRow({ comic, index }: { comic: Comic; index: number }) {
         </Typography>
       </TableCell>
       <TableCell sx={{ px: 1 }}>
-        <Checkbox checked={isPurchased} onChange={handleCheck} />
+        <Checkbox checked={comic.isPurchased} onChange={handleCheck} />
       </TableCell>
     </TableRow>
   );

--- a/src/app/components/__tests__/ComicTable.test.tsx
+++ b/src/app/components/__tests__/ComicTable.test.tsx
@@ -1,5 +1,6 @@
 import { Comic } from "@/app/type";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import ComicTable from "../ComicTable";
 
 // next/image はテスト環境では動作しないためシンプルな img に置き換える
@@ -28,16 +29,17 @@ const mockComics: Comic[] = [
 ];
 
 describe("ComicTable", () => {
-  it("コミックのタイトルが表示される", () => {
+  it("デフォルトでは「未購入」タブが選択され、未購入の漫画のみ表示される", () => {
     render(<ComicTable comics={mockComics} />);
-    expect(screen.getByText("進撃の巨人")).toBeInTheDocument();
     expect(screen.getByText("鬼滅の刃")).toBeInTheDocument();
+    expect(screen.queryByText("進撃の巨人")).not.toBeInTheDocument();
   });
 
-  it("入力者が表示される", () => {
+  it("「購入済」タブを選択すると購入済みの漫画のみ表示される", async () => {
     render(<ComicTable comics={mockComics} />);
-    expect(screen.getByText("諫山創")).toBeInTheDocument();
-    expect(screen.getByText("吾峠呼世晴")).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("tab", { name: "購入済" }));
+    expect(screen.getByText("進撃の巨人")).toBeInTheDocument();
+    expect(screen.queryByText("鬼滅の刃")).not.toBeInTheDocument();
   });
 
   it("空配列を渡した場合はローディング（CircularProgress）が表示される", () => {

--- a/src/app/components/__tests__/ComicTable.test.tsx
+++ b/src/app/components/__tests__/ComicTable.test.tsx
@@ -1,5 +1,5 @@
 import { Comic } from "@/app/type";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import ComicTable from "../ComicTable";
 
 // next/image はテスト環境では動作しないためシンプルな img に置き換える
@@ -50,5 +50,22 @@ describe("ComicTable", () => {
   it("サムネイルがない場合は「なし」が表示される", () => {
     render(<ComicTable comics={mockComics} />);
     expect(screen.getByText("なし")).toBeInTheDocument();
+  });
+
+  it("チェックボックスをクリックすると漫画がタブ間を移動する", async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: true });
+    render(<ComicTable comics={mockComics} />);
+
+    // 未購入タブで「鬼滅の刃」が表示されている
+    expect(screen.getByText("鬼滅の刃")).toBeInTheDocument();
+
+    // チェックボックスをクリック（isPurchasedをtrueに切り替え）
+    const checkbox = screen.getByRole("checkbox");
+    fireEvent.click(checkbox);
+
+    // 「鬼滅の刃」が未購入タブから消える
+    await waitFor(() => {
+      expect(screen.queryByText("鬼滅の刃")).not.toBeInTheDocument();
+    });
   });
 });

--- a/src/app/components/__tests__/ComicTable.test.tsx
+++ b/src/app/components/__tests__/ComicTable.test.tsx
@@ -1,6 +1,5 @@
 import { Comic } from "@/app/type";
-import { render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { fireEvent, render, screen } from "@testing-library/react";
 import ComicTable from "../ComicTable";
 
 // next/image はテスト環境では動作しないためシンプルな img に置き換える
@@ -35,9 +34,9 @@ describe("ComicTable", () => {
     expect(screen.queryByText("進撃の巨人")).not.toBeInTheDocument();
   });
 
-  it("「購入済」タブを選択すると購入済みの漫画のみ表示される", async () => {
+  it("「購入済」タブを選択すると購入済みの漫画のみ表示される", () => {
     render(<ComicTable comics={mockComics} />);
-    await userEvent.click(screen.getByRole("tab", { name: "購入済" }));
+    fireEvent.click(screen.getByRole("tab", { name: "購入済" }));
     expect(screen.getByText("進撃の巨人")).toBeInTheDocument();
     expect(screen.queryByText("鬼滅の刃")).not.toBeInTheDocument();
   });

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -37,16 +37,8 @@ export default function Home() {
       </AppBar>
 
       <Container maxWidth="md">
-        <Box py={5}>
-          <Box
-            display="flex"
-            alignItems="center"
-            justifyContent="space-between"
-            mb={3}
-          >
-            <Typography variant="h5" fontWeight="bold" color="text.primary">
-              リスト
-            </Typography>
+        <Box py={3}>
+          <Box display="flex" alignItems="center" justifyContent="end">
             <RegisterModal onRegisterSuccess={fetchComics} />
           </Box>
           <ComicTable comics={comics} />


### PR DESCRIPTION
テーブル上部に「未購入」「購入済」タブを追加し、
isPurchasedフラグに応じて表示する漫画を切り替える。
タブ切り替え時はページネーションをリセットする。